### PR TITLE
Closes #141

### DIFF
--- a/client/integration/ClientIntegrationTestFramework.js
+++ b/client/integration/ClientIntegrationTestFramework.js
@@ -135,6 +135,7 @@ _.extend(ClientIntegrationTestFramework.prototype, {
                     result,
                     currentId);
                 }
+              }
             }
 
             env.addReporter(serverReporter);

--- a/client/integration/ClientIntegrationTestFramework.js
+++ b/client/integration/ClientIntegrationTestFramework.js
@@ -125,13 +125,16 @@ _.extend(ClientIntegrationTestFramework.prototype, {
                   });
               },
               jasmineDone: function () {
-                window.ddpParentConnection.call("jasmine/doneConsumer", currentId)
+                if (currentId){
+                  window.ddpParentConnection.call("jasmine/doneConsumer", currentId);
+                }
               },
               specDone: function (result) {
-                window.ddpParentConnection.call("jasmine/specDoneConsumer",
-                  result,
-                  currentId)
-              }
+                if (currentId){
+                  window.ddpParentConnection.call("jasmine/specDoneConsumer",
+                    result,
+                    currentId);
+                }
             }
 
             env.addReporter(serverReporter);


### PR DESCRIPTION
Don't call methods with empty `currentId` (it's empty if `jasmine/startedConsumer` failed or not exists)