### PR TITLE
Fix result.timestamp type

### DIFF
--- a/lib/VelocityTestReporter.js
+++ b/lib/VelocityTestReporter.js
@@ -29,7 +29,7 @@
         //timeOut: test._timeout,
         //timedOut: test.timedOut,
         ancestors: ancestors,
-        timestamp: new Date().toTimeString()
+        timestamp: new Date()
       }
       if (test.failedExpectations[0]){
         result.failureMessage = test.failedExpectations[0].message


### PR DESCRIPTION
[velocity:html-reporter/lib/client-report.js](https://github.com/meteor-velocity/html-reporter/blob/devel/lib/client-report.js#L161) have this code on 161 line:

    _.each(results, function (result) {
      if (!firstTimeStamp ||  firstTimeStamp > result.timestamp.getTime()) {
        firstTimeStamp = result.timestamp.getTime();
      }
      if (!lastTimestamp ||  lastTimestamp < result.timestamp.getTime()) {
        lastTimestamp = result.timestamp.getTime();
        lastDuration = result.duration;
      }
    });

and it throws error:

    Exception in template helper: TypeError: undefined is not a function
    at http://localhost:3000/packages/velocity_html-reporter.js?a615bf3410d795106d7a78c6a94379745879f7df:651:43
    at Array.forEach (native)
    at Function._.each._.forEach (http://localhost:3000/packages/underscore.js?0a80a8623e1b40b5df5a05582f288ddd586eaa18:156:11)
    at Object.Template.velocitySummary.helpers.totalTime (http://localhost:3000/packages/velocity_html-reporter.js?a615bf3410d795106d7a78c6a94379745879f7df:649:7)
    at bindDataContext (http://localhost:3000/packages/blaze.js?efa68f65e67544b5a05509804bf97e2c91ce75eb:2727:16)
    at Blaze._wrapCatchingExceptions (http://localhost:3000/packages/blaze.js?efa68f65e67544b5a05509804bf97e2c91ce75eb:1606:16)
    at Spacebars.call (http://localhost:3000/packages/spacebars.js?7f53771c84a2eafac2b561c9796dda0d8af8e7f5:171:18)
    at Spacebars.mustacheImpl (http://localhost:3000/packages/spacebars.js?7f53771c84a2eafac2b561c9796dda0d8af8e7f5:108:25)
    at Object.Spacebars.mustache (http://localhost:3000/packages/spacebars.js?7f53771c84a2eafac2b561c9796dda0d8af8e7f5:112:39)
    at null._render (http://localhost:3000/packages/velocity_html-reporter.js?a615bf3410d795106d7a78c6a94379745879f7df:218:22)

when tryis call `getTime()` from string saved in `result.timestamp`.