### PR TITLE
Option to get rid of Chrome window

### DIFF
--- a/src/client/unit/ClientUnitTestFramework.js
+++ b/src/client/unit/ClientUnitTestFramework.js
@@ -87,13 +87,14 @@ _.extend(ClientUnitTestFramework.prototype, {
 
     var launcherPlugins = {
       'Chrome': 'karma-chrome-launcher',
+      'HiddenChrome': 'karma-chrome-launcher',
       'ChromeCanary': 'karma-chrome-launcher',
       'Firefox': 'karma-firefox-launcher',
       'PhantomJS': 'karma-phantomjs-launcher',
       'SauceLabs': 'karma-sauce-launcher'
     }
 
-    var browser = process.env.JASMINE_BROWSER || 'Chrome';
+    var browser = process.env.JASMINE_BROWSER || 'HiddenChrome';
     var launcherPlugin = launcherPlugins[browser];
 
     /* jshint camelcase: false */
@@ -102,6 +103,12 @@ _.extend(ClientUnitTestFramework.prototype, {
       basePath: Velocity.getAppPath(),
       frameworks: ['jasmine'],
       browsers: [browser],
+      customLaunchers: {
+        HiddenChrome: {
+          base: 'Chrome',
+          flags: ['--window-size=1024,768', '--window-position=-1024,0'],
+        }
+      },
       plugins: [
         'karma-jasmine',
         launcherPlugin,


### PR DESCRIPTION
Chrome doesn't seem to provide any nice option for launching with minimized or hidden windows. However, it has window-positioning options which allow to at least move the window off-screen. This little trick doesn't stop Karma from relaunching Chrome browser and does not stop the window from hiding and popping out constantly, but at least "hides" the window from user's perpective. It seems that this doesn't even steal mouse/keyboard focus from code editors. Tested on Windows only, I don't have any graphical Linux workstation at hand.