### PR TITLE
nicer stacktraces in Client Unit Tests

### DIFF
--- a/package.js
+++ b/package.js
@@ -62,6 +62,7 @@ Package.onUse(function (api) {
     'src/lib/parseStack.js',
     'src/lib/JasmineTestFramework.js',
     'src/lib/JasmineInterface.js',
+    'src/lib/JasmineVelocityTools.js',
     'src/lib/VelocityTestReporter.js'
   ], ['server', 'client'])
 
@@ -139,6 +140,8 @@ Package.onUse(function (api) {
     'src/server/unit/metadata-reader.js.tpl',
     'src/lib/mock.js',
     'src/server/lib/contextSpec.js',
+    'src/lib/parseStack.js',
+    'src/lib/JasmineVelocityTools.js',
     'src/lib/VelocityTestReporter.js',
     'src/client/unit/assets/context.html',
     'src/client/unit/assets/debug.html',

--- a/src/client/unit/ClientUnitTestFramework.js
+++ b/src/client/unit/ClientUnitTestFramework.js
@@ -251,6 +251,8 @@ _.extend(ClientUnitTestFramework.prototype, {
       this._getAssetPath('src/client/unit/assets/jasmine-jquery.js'),
       this._getAssetPath('.npm/package/node_modules/component-mocker/index.js'),
       this._getAssetPath('src/lib/mock.js'),
+      this._getAssetPath('src/lib/parseStack.js'),
+      this._getAssetPath('src/lib/JasmineVelocityTools.js'),
       this._getAssetPath('src/lib/VelocityTestReporter.js'),
       this._getAssetPath('src/client/unit/assets/adapter.js'),
       '.meteor/local/build/programs/server/assets/packages/velocity_meteor-stubs/index.js',

--- a/src/client/unit/assets/adapter.js
+++ b/src/client/unit/assets/adapter.js
@@ -244,11 +244,12 @@
             ancestors: ancestors,
             timestamp: new Date(),
             isClient: true
-          }
-          if (specResult.failedExpectations[0]){
-            velocityResult.failureMessage = specResult.failedExpectations[0].message
-            velocityResult.failureStackTrace = specResult.failedExpectations[0].stack
-          }
+          };
+
+          // Meteor.absoluteUrl() == localhost:3000
+          // Karma runs at localhost:9876 (hardcoded in 'startOptions' in ClientUnitTestFramework:getKarmaConfig)
+          var formatOptions = { rootUrl: 'http://localhost:9876/' };
+          JasmineVelocityTools.translateFailuresToVelocityStackAndMessage(velocityResult, specResult, formatOptions);
 
           ddpParentConnection.call('velocity/reports/submit', velocityResult, function (error){
             if (error){

--- a/src/lib/JasmineVelocityTools.js
+++ b/src/lib/JasmineVelocityTools.js
@@ -1,0 +1,126 @@
+/* global
+   JasmineVelocityTools: true
+ */
+
+(function () {
+  JasmineVelocityTools = {
+    translateFailuresToVelocityStackAndMessage: function translateFailuresToVelocityStackAndMessage(velocityResult, specResult, options) {
+      if (specResult.failedExpectations[0]){
+        var filtered = JasmineVelocityTools.filterStack(specResult.failedExpectations[0].stack);
+        var parsed = parseStack.parse({stack: filtered});
+        var stack = JasmineVelocityTools.removeStackTraceClutter(parsed, options);
+        var message = _.extend({
+          message: specResult.failedExpectations[0].message,
+          stack: stack
+        }, stack[0]);
+        velocityResult.failureMessage = message.message;
+        velocityResult.failureStackTrace = JasmineVelocityTools.formatMessage([message]);
+      }
+    },
+
+    filterStack: function filterStack(stack) {
+      var filteredStack = stack.split('\n').filter(function(stackLine) {
+        return stackLine.indexOf('/node_modules/jasmine-core/') === -1;
+      }).join('\n');
+      return filteredStack;
+    },
+
+    removeStackTraceClutter: function removeStackTraceClutter(parsedStackTrace, options) {
+      return _.chain(parsedStackTrace)
+        .map(_.clone)
+        .map(function makeFileUrlRelative(frame) {
+          var rootUrl = options.rootUrl;
+          console.log(frame);
+          console.log(rootUrl);
+          if (frame.file.indexOf(rootUrl) === 0) {
+            frame.file = frame.file.substr(rootUrl.length);
+          }
+          return frame;
+        })
+        .map(function removeCacheBustingQuery(frame) {
+          frame.file = frame.file.replace(/\?[a-z0-9]+$/, '');
+          return frame;
+        })
+        .map(function normalizePackageName(frame) {
+          frame.file = frame.file.replace('local-test:', '');
+          return frame;
+        })
+        .map(function removeUselessFunc(frame) {
+          if (frame.func === 'Object.<anonymous>') {
+            frame.func = null;
+          }
+          return frame;
+        })
+        .value();
+    },
+
+    formatMessage: function formatMessage(messages) {
+      var out = '';
+      var already = {};
+      var indent = '';
+
+      _.each(messages, function (message) {
+        var stack = message.stack || [];
+
+        var line = indent;
+        if (message.file) {
+          line+= message.file;
+          if (message.line) {
+            line += ":" + message.line;
+            if (message.column) {
+              // XXX maybe exclude unless specifically requested (eg,
+              // for an automated tool that's parsing our output?)
+              line += ":" + message.column;
+            }
+          }
+          line += ": ";
+        } else {
+          // not sure how to display messages without a filenanme.. try this?
+          line += "error: ";
+        }
+        // XXX line wrapping would be nice..
+        line += message.message;
+        if (message.func && stack.length <= 1) {
+          line += " (at " + message.func + ")";
+        }
+        line += "\n";
+
+        if (stack.length > 1) {
+          _.each(stack, function (frame) {
+            // If a nontrivial stack trace (more than just the file and line
+            // we already complained about), print it.
+            var where = "";
+            if (frame.file) {
+              where += frame.file;
+              if (frame.line) {
+                where += ":" + frame.line;
+                if (frame.column) {
+                  where += ":" + frame.column;
+                }
+              }
+            }
+
+            if (! frame.func && ! where)
+              return; // that's a pretty lame stack frame
+
+            line += "  at ";
+            if (frame.func)
+              line += frame.func + " (" + where + ")\n";
+            else
+              line += where + "\n";
+          });
+          line += "\n";
+        }
+
+        // Deduplicate messages (only when exact duplicates, including stack)
+        if (! (line in already)) {
+          out += line;
+          already[line] = true;
+        }
+      });
+
+      return out;
+    }
+  };
+
+})()


### PR DESCRIPTION
Velocity displayed Client-Unit test results with cluttered stacktraces. It was quite hard to read.

I've moved stacktrace parsing from VelocityTestReporter.js (I suppose it's client-integration) into JasmineVelocityTools.js and used them in client-unit adapter.js KarmaVelocityReporter. There's a catch though - the RootURL is Karma's :9876 not App's :3000, so it couldn't be read from Meteor as VelocityTestReporter did it. I have not found quick way to get it from ClientUnitTestFramework.js, and the `startOptions` have it simply hardcoded, so I just hardcoded the Karma's rootUrl in adapter.js for now for the sake of minimizing the change.

By the way, those two reporters look very similiar. The parts that create a `velocityResult` and then send it to velocity using ddp or direct call could be refactored out and shared too, but that's cosmetics.